### PR TITLE
Demo for Artix-7 devices

### DIFF
--- a/blinky-digilent_arty/Makefile
+++ b/blinky-digilent_arty/Makefile
@@ -1,0 +1,38 @@
+PREFIX ?= /snap/nextpnr-kintex/current
+DB_DIR=${PREFIX}/opt/nextpnr-xilinx/external/prjxray-db
+CHIPDB=../chipdb
+
+PART = xc7k325tffg676-1
+
+.PHONY: all
+all: blinky.bit
+
+.PHONY: program
+program: blinky.bit
+	openFPGALoader --board qmtechKintex7 --bitstream $<
+
+blinky.json: blinky.v
+	yosys -p "synth_xilinx -flatten -abc9 -nobram -arch xc7 -top blinky; write_json blinky.json" $<
+
+# The chip database only needs to be generated once
+# that is why we don't clean it with make clean
+${CHIPDB}/${PART}.bin:
+	python3 ${PREFIX}/opt/nextpnr-xilinx/python/bbaexport.py --device ${PART} --bba ${PART}.bba
+	bbasm -l ${PART}.bba ${CHIPDB}/${PART}.bin
+	rm -f ${PART}.bba
+
+blinky.fasm: blinky.json ${CHIPDB}/${PART}.bin
+	nextpnr-xilinx --chipdb ${CHIPDB}/${PART}.bin --xdc blinky.xdc --json blinky.json --fasm $@ --verbose --debug
+	
+blinky.frames: blinky.fasm
+	fasm2frames --part ${PART} --db-root ${DB_DIR}/kintex7 $< > $@
+
+blinky.bit: blinky.frames
+	xc7frames2bit --part_file ${DB_DIR}/kintex7/${PART}/part.yaml --part_name ${PART} --frm_file $< --output_file $@
+
+.PHONY: clean
+clean:
+	@rm -f *.bit
+	@rm -f *.frames
+	@rm -f *.fasm
+	@rm -f *.json

--- a/blinky-digilent_arty/Makefile
+++ b/blinky-digilent_arty/Makefile
@@ -2,14 +2,15 @@ PREFIX ?= /snap/nextpnr-kintex/current
 DB_DIR=${PREFIX}/opt/nextpnr-xilinx/external/prjxray-db
 CHIPDB=../chipdb
 
-PART = xc7k325tffg676-1
+#PART = xc7a100tcsg324-1
+PART = xc7a35tcsg324-1
 
 .PHONY: all
 all: blinky.bit
 
 .PHONY: program
 program: blinky.bit
-	openFPGALoader --board qmtechKintex7 --bitstream $<
+	openFPGALoader --board arty --bitstream $<
 
 blinky.json: blinky.v
 	yosys -p "synth_xilinx -flatten -abc9 -nobram -arch xc7 -top blinky; write_json blinky.json" $<
@@ -25,10 +26,10 @@ blinky.fasm: blinky.json ${CHIPDB}/${PART}.bin
 	nextpnr-xilinx --chipdb ${CHIPDB}/${PART}.bin --xdc blinky.xdc --json blinky.json --fasm $@ --verbose --debug
 	
 blinky.frames: blinky.fasm
-	fasm2frames --part ${PART} --db-root ${DB_DIR}/kintex7 $< > $@
+	fasm2frames --part ${PART} --db-root ${DB_DIR}/artix7 $< > $@ #FIXME: fasm2frames should be on PATH
 
 blinky.bit: blinky.frames
-	xc7frames2bit --part_file ${DB_DIR}/kintex7/${PART}/part.yaml --part_name ${PART} --frm_file $< --output_file $@
+	xc7frames2bit --part_file ${DB_DIR}/artix7/${PART}/part.yaml --part_name ${PART} --frm_file $< --output_file $@
 
 .PHONY: clean
 clean:

--- a/blinky-digilent_arty/blinky.v
+++ b/blinky-digilent_arty/blinky.v
@@ -1,0 +1,13 @@
+`default_nettype none   //do not allow undeclared wires
+
+module blinky (
+    input  wire clk,
+    output wire led
+    );
+
+    reg [24:0] r_count = 0;
+
+    always @(posedge(clk)) r_count <= r_count + 1;
+
+    assign led = r_count[24];
+endmodule

--- a/blinky-digilent_arty/blinky.xdc
+++ b/blinky-digilent_arty/blinky.xdc
@@ -1,5 +1,6 @@
-set_property LOC F22 [get_ports clk]
+set_property LOC E3 [get_ports clk]
 set_property IOSTANDARD LVCMOS33 [get_ports {clk}]
 
-set_property LOC J26 [get_ports led]
+set_property LOC H5 [get_ports led]
 set_property IOSTANDARD LVCMOS33 [get_ports {led}]
+

--- a/blinky-digilent_arty/blinky.xdc
+++ b/blinky-digilent_arty/blinky.xdc
@@ -1,0 +1,5 @@
+set_property LOC F22 [get_ports clk]
+set_property IOSTANDARD LVCMOS33 [get_ports {clk}]
+
+set_property LOC J26 [get_ports led]
+set_property IOSTANDARD LVCMOS33 [get_ports {led}]


### PR DESCRIPTION
I made blinky work on the Digilent Arty-35T board, based on the qmtech demo
It required to put fasm2frames on path: `export PATH=/snap/nextpnr-kintex/x1/bin:$PATH`

Specific changes (they're really minimal) can be seen on this commit: https://github.com/kintex-chatter/demo-projects/commit/a514a5c43122077b3ad1d7399d85d4549c4af399

