### PR TITLE
litex-ddr-stlv7325: fix Makefile

### DIFF
--- a/litex-ddr-stlv7325/Makefile
+++ b/litex-ddr-stlv7325/Makefile
@@ -1,40 +1,10 @@
-PROJECT_NAME = sitlinv_stlv7325
-PREFIX ?= /snap/openxc7/current
-DB_DIR=${PREFIX}/opt/nextpnr-xilinx/external/prjxray-db
-CHIPDB=../chipdb
+FAMILY  = kintex7
+PART    = xc7k325tffg676-1
+BOARD   = stlv7325
+PROJECT = sitlinv_stlv7325
+
 VEXRISCV=../vexriscv
+ADDITIONAL_SOURCES=${VEXRISCV}/VexRiscv.v
 
-PART = xc7k325tffg676-1
-
-.PHONY: all
-all: ${PROJECT_NAME}.bit
-
-${PROJECT_NAME}.json: ${PROJECT_NAME}.v
-	yosys -p "hierarchy; synth_xilinx -flatten -abc9 -arch xc7 -top ${PROJECT_NAME}; write_json ${PROJECT_NAME}.json;" $< ../vexriscv/VexRiscv.v
-
-# The chip database only needs to be generated once
-# that is why we don't clean it with make clean
-${CHIPDB}/${PART}.bin:
-	pypy3 ${PREFIX}/opt/nextpnr-xilinx/python/bbaexport.py --device ${PART} --bba ${PART}.bba
-	bbasm -l ${PART}.bba ${CHIPDB}/${PART}.bin
-	rm -f ${PART}.bba
-
-${PROJECT_NAME}.fasm: ${PROJECT_NAME}.json ${CHIPDB}/${PART}.bin
-	nextpnr-xilinx --chipdb ${CHIPDB}/${PART}.bin --xdc ${PROJECT_NAME}.xdc  --json $< --write ${PROJECT_NAME}_routed.json --fasm $@  --freq 50 #--router router2 #--debug-router ##--verbose --debug
-
-${PROJECT_NAME}.frames: ${PROJECT_NAME}.fasm
-	fasm2frames --part ${PART} --db-root ${DB_DIR}/kintex7 $< > $@
-
-${PROJECT_NAME}.bit: ${PROJECT_NAME}.frames
-	xc7frames2bit --part_file ${DB_DIR}/kintex7/${PART}/part.yaml --part_name ${PART} --frm_file $< --output_file $@
-
-.PHONY: clean pnrclean
-clean:
-	@rm -f *.bit
-	@rm -f *.frames
-	@rm -f *.fasm
-	@rm -f *.json
-
-pnrclean:
-	rm *.fasm *.frames *.bit
+include ../openXC7.mk
 


### PR DESCRIPTION
Reworked the Makefile for litex-ddr-stlv7325 example in the same manner as e4a4ffa93829d93ebd7cf4a1df45c85feeea3e25.

Tested the build with nix version of the toolchain.

EDIT: I should've probably mentioned that the old version didn't work for me, hence the need for the rework