### PR TITLE
Add:AllAboutFPGA[dot]com EdgeZ7-20 blinky project.

### DIFF
--- a/blinky-allaboutfpga-edgez7-20/Makefile
+++ b/blinky-allaboutfpga-edgez7-20/Makefile
@@ -1,0 +1,7 @@
+FAMILY  = zynq7
+PART    = xc7z020clg400-1
+BOARD   = pynq_z1
+PROJECT = blinky
+CHIPDB  = ${ZYNQ7_CHIPDB}
+
+include ../openXC7.mk

--- a/blinky-allaboutfpga-edgez7-20/README.md
+++ b/blinky-allaboutfpga-edgez7-20/README.md
@@ -1,0 +1,9 @@
+The AllAboutFPGA[dot]com EdgeZ7-20 development board is not currently supported by OpenFPGALoader. 
+However, it uses the same SoC as the PYNQ-Z1, the Xilinx Zynq-7020 (part number XC7Z020-1CLG400C), 
+and features an FTDI FT2232H for programming. 
+
+To enable support in OpenFPGALoader, I have applied the same configuration settings as those used 
+for the PYNQ-Z1 in the makefile. 
+
+I am currently coordinating with the OpenFPGALoader team to officially add support for the EdgeZ7-20 board. 
+Once support is added, I will update the configuration accordingly.

--- a/blinky-allaboutfpga-edgez7-20/blinky.v
+++ b/blinky-allaboutfpga-edgez7-20/blinky.v
@@ -1,0 +1,13 @@
+`default_nettype none   //do not allow undeclared wires
+
+module blinky (
+    input  wire clk,
+    output wire led
+    );
+
+    reg [24:0] r_count = 0;
+
+    always @(posedge(clk)) r_count <= r_count + 1;
+
+    assign led = r_count[24];
+endmodule

--- a/blinky-allaboutfpga-edgez7-20/blinky.xdc
+++ b/blinky-allaboutfpga-edgez7-20/blinky.xdc
@@ -1,0 +1,6 @@
+set_property PACKAGE_PIN U18 [get_ports clk]
+set_property IOSTANDARD LVCMOS33 [get_ports clk]
+# LEDs
+set_property PACKAGE_PIN R16 [get_ports led]
+set_property IOSTANDARD LVCMOS33 [get_ports {led}]
+


### PR DESCRIPTION
Hi ,

This PR adds the source files and Makefile for the Blinky demo targeting the AllAboutFPGA EdgeZ7-20 development board.

Since the board is not yet officially supported by OpenFPGALoader, I’ve used the same configuration as the PYNQ-Z1, which shares the same SoC (Zynq-7020) and FT2232H interface.

A brief note on this included in the README.

I’m currently coordinating with the OpenFPGALoader team and will update the config once official support is added.

Thanks!
Pradeep