### PR TITLE
Add .DELETE_ON_ERROR so a failed fasm2frames cannot leave a bitstream-shaped file

### DIFF
--- a/openXC7.mk
+++ b/openXC7.mk
@@ -23,6 +23,18 @@ JTAG_LINK ?= --board ${BOARD}
 
 XDC ?= ${PROJECT}.xdc
 
+# fasm2frames writes its target through a shell redirection, so a failure part-way
+# leaves a truncated .frames that is NEWER than its prerequisite. The next make then
+# skips regenerating it and feeds the partial file to xc7frames2bit, which happily
+# produces a normal-looking ~9.7 MB bitstream. It flashes, reports done 1, and the
+# board does nothing -- done 1 means configuration completed, not that the design works.
+# A CI matrix that checks only "was a .bit produced" reports green on exactly this.
+#
+# .DELETE_ON_ERROR makes make remove a target whose recipe failed, so the next run
+# rebuilds it instead of building on top of the wreckage. It covers .fasm, .json and
+# .bit as well, at no cost when nothing fails.
+.DELETE_ON_ERROR:
+
 .PHONY: all
 all: ${PROJECT}.bit
 


### PR DESCRIPTION
## The problem

`fasm2frames` writes its target through a shell redirection:

```make
${PROJECT}.frames: ${PROJECT}.fasm
	fasm2frames --part ${PART} --db-root ${PRJXRAY_DB_DIR}/${FAMILY} $< > $@
```

The shell creates `$@` before the command finishes. If `fasm2frames` fails part-way, a **truncated `.frames` survives and is newer than its prerequisite**, so the next `make` skips regenerating it and hands the partial file to `xc7frames2bit`.

`xc7frames2bit` does not mind. It produces a normal-looking **~9.7 MB** bitstream that flashes successfully and reports `done 1` — and the board does nothing. `done 1` means configuration completed, not that your design is on the board.

This cost me several hours before I worked out it was not my design that was broken.

## Why it matters for the CI matrix

A check of the form *"was a `.bit` produced?"* **reports green on exactly this failure**. The artefact exists, has a plausible size, and is wrong.

## The fix

One line. `.DELETE_ON_ERROR:` is a standard Make special target that removes a target whose recipe failed, so the next run rebuilds it instead of building on top of the wreckage. It covers `.fasm`, `.json` and `.bit` as well, and costs nothing when nothing fails.

Verified on a minimal makefile:

```
without .DELETE_ON_ERROR: failed target left behind = YES
with    .DELETE_ON_ERROR: failed target left behind = no
```

## Scope

`openXC7.mk` is included by all 26 project directories, so this applies to the whole tree. No project files are touched and no behaviour changes on a successful build.

## What I did not change

`synth_xilinx` is invoked with `-arch xc7` here. In my own flow that option is `-family xc7`, but since these projects build, the spelling is evidently valid for the yosys version this targets — so I left it alone rather than guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)